### PR TITLE
feat: add transformValidatedStripTypes method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,34 @@ export function transformSync(
 		...options,
 	});
 }
+
+function doesTSStripTypesResultMatchSource(code: string, source: string) {
+	if (code.length !== source.length) return false;
+	for (let i = 0; i < code.length; i++) {
+		// Might return charcodes if surrogate pair started at i-1, which is fine
+		// All values swc ever inserts are below \u{10000} and are not UTF-16 surrogate pairs, while some are 3-byte UTF-8
+		// We still need to check codePointAt to ensure that already started surrogate pairs at i-1 are not broken by this insertion
+		const a = code.codePointAt(i);
+		if (a === source.codePointAt(i)) continue;
+		// https://github.com/nodejs/amaro/blob/e533394f576f946add41dd8816816435e8100c3b/deps/swc/crates/swc_fast_ts_strip/src/lib.rs#L400-L414
+		// https://github.com/nodejs/amaro/blob/e533394f576f946add41dd8816816435e8100c3b/deps/swc/crates/swc_fast_ts_strip/src/lib.rs#L200-L226
+		if (
+			a !== 0x20 && // 0020 Space [20]
+			a !== 0x3b && // 003b Semicolon ; [3b]
+			a !== 0xa0 && // 00A0 No-Break Space [c2 a0]
+			a !== 0x2002 && // 2002 En Space [e2 80 82]
+			a !== 0xfeff // FEFF ZWNBSP [ef bb bf]
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+export function transformValidatedStripTypes(source: string): string {
+	const { code } = transformSync(source, { mode: "strip-only" });
+	if (!doesTSStripTypesResultMatchSource(code, source)) {
+		throw new Error("swc returned unexpected transform result");
+	}
+	return code;
+}

--- a/test/validatedStripTypes.test.js
+++ b/test/validatedStripTypes.test.js
@@ -1,0 +1,17 @@
+const { describe, test } = require("node:test");
+const assert = require("node:assert");
+const { transformValidatedStripTypes } = require("../dist/index.js");
+
+describe("transformValidatedStripTypes", () => {
+	test("should perform type stripping", () => {
+		assert.strictEqual(typeof transformValidatedStripTypes, "function");
+		const code = transformValidatedStripTypes("const foo: string = 'bar';");
+		assert.strictEqual(code, "const foo         = 'bar';");
+	});
+
+	test("should perform type stripping with multi-byte types", () => {
+		assert.strictEqual(typeof transformValidatedStripTypes, "function");
+		const code = transformValidatedStripTypes("const foo: äöü = 'bar';");
+		assert.strictEqual(code, "const foo      = 'bar';");
+	});
+});


### PR DESCRIPTION
Solves #17 

It deliberately does not return anything except `code`, as (1) only that is ever needed in strip-only mode (2) anything else would have been unvalidated

One of the reasons why this is a new method (except for additional options overcomplicating things)