### PR TITLE
fix(test): fix 'npm test' under Node.js 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"postpack": "npm run clean",
 		"build": "rspack build",
 		"typecheck": "tsc --noEmit",
-		"test": "node --test ./test"
+		"test": "node --test ./test/*.test.js"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.8.3",


### PR DESCRIPTION
Dir is not accepted anymore, globs patterns are (not not compatible to 20)
Which means full file paths are ok

Not using `'**/*'` or `'*'` as it's not parsed by Node.js 20, not using `**/*` as not all shells expand it, so `*`

Assuming all tests are on single level

Refs: https://nodejs.org/api/test.html#running-tests-from-the-command-line