### PR TITLE
chore(ci): Add commit linting workflow

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,17 @@
+name: Lint PR
+
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+    commit-lint:
+        name: Commit Lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+            - uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
Fix #27

This action uses conventional commit config by default. If needed, I can refactor to use the same setup as the node repo.
Named the workflow `Lint PR` in case we want to also lint the PR title in another job.