### PR TITLE
chore(tools): enclose test glob patterns in quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
 		"postpack": "npm run clean",
 		"build": "rspack build",
 		"typecheck": "tsc --noEmit",
-		"test": "node --test --experimental-test-snapshots **/*.test.js",
-		"test:regenerate": "node --test --experimental-test-snapshots --test-update-snapshots **/*.test.js"
+		"test": "node --test --experimental-test-snapshots \"**/*.test.js\"",
+		"test:regenerate": "node --test --experimental-test-snapshots --test-update-snapshots \"**/*.test.js\""
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.8.3",


### PR DESCRIPTION
If you want to rely on node’s test runner’s glob expansion the glob patterns should be enclosed in quotes. Otherwise the shell will do the glob expansion which can have different behaviors depending on the system. 

> The glob patterns should be enclosed in double quotes on the command line to prevent shell expansion, which can reduce portability across systems.

https://nodejs.org/docs/latest/api/test.html#running-tests-from-the-command-line