### PR TITLE
chore: add correct defaults

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -3,6 +3,13 @@ import swc from "../lib/wasm.js";
 
 const DEFAULT_OPTIONS = {
 	mode: "strip-only",
+	// default transform will only work when mode is "transform"
+	transform: {
+		verbatimModuleSyntax: true,
+		nativeClassProperties: true,
+		noEmptyExport: true,
+		importNotUsedAsValues: "preserve",
+	},
 } as Options;
 
 export function transformSync(

--- a/test/snapshots/transform.test.js.snapshot
+++ b/test/snapshots/transform.test.js.snapshot
@@ -53,3 +53,7 @@ exports[`should transform TypeScript type annotations and type guards 1`] = `
 exports[`test native class properties 1`] = `
 "class Foo {\\n    y;\\n    x = console.log(1);\\n    constructor(y = console.log(2)){\\n        this.y = y;\\n        console.log(3);\\n    }\\n}\\n"
 `;
+
+exports[`test noEmptyExport 1`] = `
+"const fs = require(\\"fs\\");\\n"
+`;

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -23,9 +23,6 @@ test("should perform transformation without source maps", (t) => {
 
 	const { code, map } = transformSync(tsCode, {
 		mode: "transform",
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -45,9 +42,6 @@ test("should perform transformation without source maps and filename", (t) => {
 	const { code, map } = transformSync(tsCode, {
 		mode: "transform",
 		filename: "foo.ts",
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -68,9 +62,6 @@ test("should perform transformation with source maps", (t) => {
 		mode: "transform",
 		sourceMap: true,
 		filename: "foo.ts",
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -90,9 +81,6 @@ test("should perform transformation with source maps no filename", (t) => {
 	const { code, map } = transformSync(tsCode, {
 		mode: "transform",
 		sourceMap: true,
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -114,9 +102,6 @@ test("should perform transformation with error", (t) => {
 		mode: "transform",
 		sourceMap: true,
 		filename: "foo.ts",
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -146,9 +131,6 @@ test("should transform TypeScript class fields", (t) => {
 	const { code } = transformSync(inputCode, {
 		mode: "transform",
 		sourceMap: true,
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -175,9 +157,6 @@ test("should transform TypeScript private class fields", (t) => {
 	const { code } = transformSync(inputCode, {
 		mode: "transform",
 		sourceMap: true,
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -196,9 +175,6 @@ test("should transform TypeScript type annotations and type guards", (t) => {
 	const { code } = transformSync(inputCode, {
 		mode: "transform",
 		sourceMaps: true,
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -232,9 +208,6 @@ test("should transform TypeScript class decorators with multiple decorators", (t
 	const { code } = transformSync(inputCode, {
 		mode: "transform",
 		sourceMap: true,
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -272,9 +245,6 @@ test("should transform TypeScript namespaces with additional functionality", (t)
 	const { code } = transformSync(inputCode, {
 		mode: "transform",
 		sourceMap: true,
-		transform: {
-			verbatimModuleSyntax: true,
-		},
 	});
 
 	t.assert.snapshot(code);
@@ -294,10 +264,17 @@ test("test native class properties", (t) => {
 	const { code } = transformSync(inputCode, {
 		mode: "transform",
 		sourceMap: true,
-		transform: {
-			verbatimModuleSyntax: true,
-			nativeClassProperties: true,
-		},
+	});
+	t.assert.snapshot(code);
+});
+
+test("test noEmptyExport", (t) => {
+	const inputCode = `
+	import fs = require("fs");
+	`;
+	const { code } = transformSync(inputCode, {
+		mode: "transform",
+		sourceMap: true,
 	});
 	t.assert.snapshot(code);
 });


### PR DESCRIPTION
cc @nodejs/typescript 
I also wonder which other options we should set by default during transformation
```typescript
interface TransformConfig {
    /**
     * @see https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax
     */
    verbatimModuleSyntax?: boolean;
    /**
     * Native class properties support
     */
    nativeClassProperties?: boolean;
    importNotUsedAsValues?: "remove" | "preserve";
    /**
     * Don't create `export {}`.
     * By default, strip creates `export {}` for modules to preserve module
     * context.
     * 
     * @see https://github.com/swc-project/swc/issues/1698
     */
    noEmptyExport?: boolean;
    importExportAssignConfig?: "Classic" | "Preserve" | "NodeNext" | "EsNext";
    /**
     * Disables an optimization that inlines TS enum member values
     * within the same module that assumes the enum member values
     * are never modified.
     * 
     * Defaults to false.
     */
    tsEnumIsMutable?: boolean;
}
```

I think `importNotUsedAsValues: "preserve"` others idk which are defaults