### PR TITLE
chore(workflow): update node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         node:
           - 22
+          - 23
         platform:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build


### PR DESCRIPTION
- For release workflow, we use `.nvmrc`
- For CI, we use `22` and `23` for test