### PR TITLE
test: ensure loaders passes for non ts

### DIFF
--- a/test/fixtures/hello.js
+++ b/test/fixtures/hello.js
@@ -1,0 +1,1 @@
+console.log("Hello, JavaScript!");

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -67,3 +67,29 @@ test("should not warn and accurate stracktrace", async () => {
 	match(result.stderr, /stacktrace.ts:4:7/); // accurate
 	strictEqual(result.code, 1);
 });
+
+test("should call nextLoader for non-typescript files for striping", async () => {
+	const result = await spawnPromisified(process.execPath, [
+		"--experimental-strip-types",
+		"--no-warnings",
+		"--import=./dist/register-strip.mjs",
+		fixturesPath("hello.js"),
+	]);
+
+	strictEqual(result.stderr, "");
+	match(result.stdout, /Hello, JavaScript!/);
+	strictEqual(result.code, 0);
+});
+
+test("should call nextLoader for non-typescript files for transform", async () => {
+	const result = await spawnPromisified(process.execPath, [
+		"--experimental-strip-types",
+		"--no-warnings",
+		"--import=./dist/register-transform.mjs",
+		fixturesPath("hello.js"),
+	]);
+
+	strictEqual(result.stderr, "");
+	match(result.stdout, /Hello, JavaScript!/);
+	strictEqual(result.code, 0);
+});


### PR DESCRIPTION
Hi :blush: I was looking into tests code coverage and it seems that for non typescript files we're not ensuring that `nextLoad` is called, there:
https://github.com/nodejs/amaro/blob/2ebb06345322ed1fa938426aa9673b886ce12e6c/src/strip-loader.ts#L35 and there:
https://github.com/nodejs/amaro/blob/2ebb06345322ed1fa938426aa9673b886ce12e6c/src/transform-loader.ts#L43

This PR adds tests that checks that, but if You think that it is something that is not worth to test please let me know so I will close this PR.
Also wondering: is there any reason why test coverage for amaro is not configured here https://app.codecov.io/gh/nodejs? or it's just luck of time/resources?