### PR TITLE
chore: remove unused licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,9 +12,6 @@ allow = [
     "MPL-2.0",
     "BSD-3-Clause",
     "BSD-2-Clause",
-    "ISC",
-    "0BSD",
-    "CC0-1.0",
     "Unicode-DFS-2016",
     "BSL-1.0"
 ]


### PR DESCRIPTION
They were warning in cargo-deny since not needed