### PR TITLE
chore: include chore in change logs

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,6 +14,7 @@
 	},
 	"files": {
 		"ignore": [
+			"package.json",
 			"dist/**",
 			"deps/**",
 			"lib/**",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,18 @@
 	"packages": {
 		".": {
 			"include-component-in-tag": false,
-			"changelog-path": "CHANGELOG.md"
+			"changelog-path": "CHANGELOG.md",
+			"changelog-sections": [
+				{ "type": "feat", "section": "Features", "hidden": false },
+				{ "type": "fix", "section": "Bug Fixes", "hidden": false },
+				{ "type": "perf", "section": "Core", "hidden": false },
+				{ "type": "docs", "section": "Core", "hidden": false },
+				{ "type": "refactor", "section": "Core", "hidden": false },
+				{ "type": "test", "section": "Core", "hidden": false },
+				{ "type": "chore", "section": "Miscellaneous", "hidden": false },
+				{ "type": "build", "section": "Miscellaneous", "hidden": false },
+				{ "type": "ci", "section": "Miscellaneous", "hidden": false }
+			]
 		}
 	}
 }


### PR DESCRIPTION
By default, release-please ignores `chore` categories in the change log ([ref](https://github.com/conventional-changelog/conventional-changelog/blob/8076d4666c2a3ea728b95bf1e4e78d4c7189b1dc/packages/conventional-changelog-conventionalcommits/writer-opts.js#L171)).