### PR TITLE
refactor: remove errors.ts as an entry point

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -28,13 +28,6 @@ await build({
 });
 
 await build({
-	entryPoints: ["src/errors.ts"],
-	platform: "node",
-	target: "node22",
-	outfile: "dist/errors.js",
-});
-
-await build({
 	entryPoints: ["src/strip-loader.ts"],
 	bundle: false,
 	outfile: "dist/strip-loader.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,6 @@
-export { transformSync } from "./transform.ts";
+export { transformSync } from "./internal/transform.ts";
+export {
+  SwcError,
+  isSwcError,
+  wrapAndReThrowSwcError,
+} from './internal/errors.ts';

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -1,4 +1,4 @@
-type SwcError = {
+export type SwcError = {
 	code: "UnsupportedSyntax" | "InvalidSyntax";
 	message: string;
 };

--- a/src/internal/transform.ts
+++ b/src/internal/transform.ts
@@ -1,5 +1,5 @@
-import type { Options, TransformOutput } from "../lib/wasm";
-import swc from "../lib/wasm.js";
+import type { Options, TransformOutput } from "../../lib/wasm";
+import swc from "../../lib/wasm.js";
 
 const DEFAULT_OPTIONS = {
 	mode: "strip-only",

--- a/src/strip-loader.ts
+++ b/src/strip-loader.ts
@@ -1,6 +1,5 @@
 import type { LoadFnOutput, LoadHookContext } from "node:module";
-import { isSwcError, wrapAndReThrowSwcError } from "./errors.js";
-import { transformSync } from "./index.js";
+import { transformSync, isSwcError, wrapAndReThrowSwcError } from "./index.js";
 
 export async function load(
 	url: string,

--- a/src/transform-loader.ts
+++ b/src/transform-loader.ts
@@ -1,7 +1,6 @@
 import type { LoadFnOutput, LoadHookContext } from "node:module";
 import type { Options } from "../lib/wasm";
-import { isSwcError, wrapAndReThrowSwcError } from "./errors.js";
-import { transformSync } from "./index.js";
+import { transformSync, isSwcError, wrapAndReThrowSwcError } from "./index.js";
 
 export async function load(
 	url: string,


### PR DESCRIPTION
`dist/error.js` is not exposed in `package.json#exports` so no need to expose it as an entry point.

Reorganize internal structure to group APIs in `src/internal`.