### PR TITLE
test: swc allows invalid js syntax

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -210,3 +210,7 @@ test("should not throw on yield new line when stripped", (t) => {
 	const result = vm.runInContext(code, vm.createContext());
 	assert.strictEqual(result, 5);
 });
+
+test("should throw invalid syntax error", (t) => {
+	assert.throws(() => transformSync("const foo;"));
+});


### PR DESCRIPTION
Refs: https://github.com/swc-project/swc/issues/9883

@nodejs/typescript I'm pretty sure this syntax should be invalid and should throw a syntax error.