### PR TITLE
test: check erasable namespaces are supported

### DIFF
--- a/test/snapshots/index.test.js.snapshot
+++ b/test/snapshots/index.test.js.snapshot
@@ -1,3 +1,27 @@
+exports[`erasable namespaces and modules should be supported 1`] = `
+"                  "
+`;
+
+exports[`erasable namespaces and modules should be supported 2`] = `
+"                    \\n    \\t\\t                \\n\\n    \\t\\t                           \\n\\n   \\t\\t\\t                     \\n\\n\\t\\t\\t                        \\n\\t\\t\\t\\t                  \\n\\t\\t\\t \\n\\t\\t "
+`;
+
+exports[`erasable namespaces and modules should be supported 3`] = `
+"                             \\n    \\t\\t                         \\n\\t\\t "
+`;
+
+exports[`erasable namespaces and modules should be supported 4`] = `
+"                                        "
+`;
+
+exports[`erasable namespaces and modules should be supported 5`] = `
+"                                        "
+`;
+
+exports[`erasable namespaces and modules should be supported 6`] = `
+"                                   "
+`;
+
 exports[`should handle User type and isAdult function 1`] = `
 "\\n                 \\n                   \\n                  \\n      \\n\\n    function isAdult(user      )          {\\n      return user.age >= 18;\\n    }\\n  "
 `;


### PR DESCRIPTION
@kdy1 I think we should support type stripping of empty namespaces because they are erasable and are supported by erasableSyntaxOnly

cc @nodejs/typescript 

Tests copied from https://github.com/bloomberg/ts-blank-space/pull/32