### PR TITLE
refactor: move tests to esm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,5 @@ jobs:
       - run: npm install
       - run: npm run typecheck
       - run: npm run build
+      - run: npm run lint:package
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.4.1",
 	"description": "Node.js TypeScript wrapper",
 	"license": "MIT",
-	"type": "commonjs",
+	"type": "module",
 	"main": "dist/index.js",
 	"homepage": "https://github.com/nodejs/amaro#readme",
 	"bugs": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/nodejs/amaro.git"
+		"url": "git+https://github.com/nodejs/amaro.git"
 	},
 	"scripts": {
 		"clean": "rimraf dist",
@@ -25,13 +25,15 @@
 		"build:wasm": "node tools/build-wasm.js",
 		"typecheck": "tsc --noEmit",
 		"test": "node --test --experimental-test-snapshots \"**/*.test.js\"",
-		"test:regenerate": "node --test --experimental-test-snapshots --test-update-snapshots \"**/*.test.js\""
+		"test:regenerate": "node --test --experimental-test-snapshots --test-update-snapshots \"**/*.test.js\"",
+		"lint:package": "publint"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.8.3",
 		"@types/node": "^22.0.0",
 		"esbuild": "^0.23.0",
 		"esbuild-plugin-copy": "^2.1.1",
+		"publint": "^0.3.8",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.5.3"
 	},

--- a/src/transform-loader.ts
+++ b/src/transform-loader.ts
@@ -1,5 +1,5 @@
 import type { LoadFnOutput, LoadHookContext } from "node:module";
-import type { Options } from "../lib/wasm";
+import type { Options } from "../lib/wasm.js";
 import { isSwcError, wrapAndReThrowSwcError } from "./errors.js";
 import { transformSync } from "./index.js";
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,4 @@
-import type { Options, TransformOutput } from "../lib/wasm";
+import type { Options, TransformOutput } from "../lib/wasm.js";
 import swc from "../lib/wasm.js";
 
 const DEFAULT_OPTIONS = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,13 +1,13 @@
-const { test, snapshot } = require("node:test");
-const { transformSync } = require("../dist/index.js");
-const path = require("node:path");
-const assert = require("node:assert");
-const vm = require("node:vm");
+import assert from "node:assert";
+import path from "node:path";
+import { snapshot, test } from "node:test";
+import vm from "node:vm";
+import { transformSync } from "../dist/index.js";
 
 // Set the path for the snapshots directory
 snapshot.setResolveSnapshotPath((testPath) => {
 	return path.join(
-		__dirname,
+		import.meta.dirname,
 		"snapshots",
 		`${path.basename(testPath)}.snapshot`,
 	);

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,6 +1,6 @@
-const { spawnPromisified, fixturesPath } = require("./util/util.js");
-const { test } = require("node:test");
-const { match, doesNotMatch, strictEqual } = require("node:assert");
+import { doesNotMatch, match, strictEqual } from "node:assert";
+import { test } from "node:test";
+import { fixturesPath, spawnPromisified } from "./util/util.js";
 
 test("should work as a loader", async () => {
 	const result = await spawnPromisified(process.execPath, [

--- a/test/snapshots/index.test.js.snapshot
+++ b/test/snapshots/index.test.js.snapshot
@@ -14,14 +14,6 @@ exports[`erasable namespaces and modules should be supported 4`] = `
 "                                        "
 `;
 
-exports[`erasable namespaces and modules should be supported 5`] = `
-"                                        "
-`;
-
-exports[`erasable namespaces and modules should be supported 6`] = `
-"                                   "
-`;
-
 exports[`should handle User type and isAdult function 1`] = `
 "\\n                 \\n                   \\n                  \\n      \\n\\n    function isAdult(user      )          {\\n      return user.age >= 18;\\n    }\\n  "
 `;

--- a/test/snapshots/snapshot-config.js
+++ b/test/snapshots/snapshot-config.js
@@ -1,5 +1,5 @@
-const { basename, dirname, extname, join } = require("node:path");
-const { snapshot } = require("node:test");
+import { basename, dirname, extname, join } from "node:path";
+import { snapshot } from "node:test";
 
 snapshot.setResolveSnapshotPath(generateSnapshotPath);
 

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -1,13 +1,13 @@
-const { test, snapshot } = require("node:test");
-const { transformSync } = require("../dist/index.js");
-const path = require("node:path");
-const assert = require("node:assert");
-const vm = require("node:vm");
+import assert from "node:assert";
+import path from "node:path";
+import { snapshot, test } from "node:test";
+import vm from "node:vm";
+import { transformSync } from "../dist/index.js";
 
 // Set the path for the snapshots directory
 snapshot.setResolveSnapshotPath((testPath) => {
 	return path.join(
-		__dirname,
+		import.meta.dirname,
 		"snapshots",
 		`${path.basename(testPath)}.snapshot`,
 	);

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -1,7 +1,7 @@
-const { spawn } = require("node:child_process");
-const path = require("node:path");
+import { spawn } from "node:child_process";
+import path from "node:path";
 
-function spawnPromisified(...args) {
+export function spawnPromisified(...args) {
 	let stderr = "";
 	let stdout = "";
 
@@ -35,10 +35,8 @@ function spawnPromisified(...args) {
 	});
 }
 
-const fixturesDir = path.join(__dirname, "..", "fixtures");
+const fixturesDir = path.join(import.meta.dirname, "..", "fixtures");
 
-function fixturesPath(...args) {
+export function fixturesPath(...args) {
 	return path.join(fixturesDir, ...args);
 }
-
-module.exports = { spawnPromisified, fixturesPath };


### PR DESCRIPTION
I think this clears from a weird situtation where shipped evertything esm but marked the module as commonjs.
Now we mark as esm but we publish the index.js as commonjs which shouldnt really matter.
The tests are now esm too
@nodejs/typescript wdyt