### PR TITLE
feat: build error snippet manually

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,12 @@
 type SwcError = {
 	code: "UnsupportedSyntax" | "InvalidSyntax";
 	message: string;
+	startColumn: number;
+	startLine: number;
+	snippet: string;
+	filename: string;
+	endColumn: number;
+	endLine: number;
 };
 
 // Type guard to check if error is SwcError
@@ -10,14 +16,19 @@ export function isSwcError(error: unknown): error is SwcError {
 
 // Since swc throw an object, we need to wrap it in a proper error
 export function wrapAndReThrowSwcError(error: SwcError): never {
+	const errorHints = `${error.filename}:${error.startLine}${error.snippet}`;
 	switch (error.code) {
 		case "UnsupportedSyntax": {
 			const unsupportedSyntaxError = new Error(error.message);
 			unsupportedSyntaxError.name = "UnsupportedSyntaxError";
+			unsupportedSyntaxError.stack = `${errorHints}${unsupportedSyntaxError.stack}`;
 			throw unsupportedSyntaxError;
 		}
-		case "InvalidSyntax":
-			throw new SyntaxError(error.message);
+		case "InvalidSyntax": {
+			const syntaxError = new SyntaxError(error.message);
+			syntaxError.stack = `${errorHints}${syntaxError.stack}`;
+			throw syntaxError;
+		}
 		default:
 			throw new Error(error.message);
 	}

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -15,7 +15,7 @@ test("should work as a loader", async () => {
 	strictEqual(result.code, 0);
 });
 
-test("should not work with enums", async () => {
+test("should not work with enums", async (t) => {
 	const result = await spawnPromisified(process.execPath, [
 		"--experimental-strip-types",
 		"--no-warnings",
@@ -95,14 +95,13 @@ test("should call nextLoader for non-typescript files for transform", async () =
 	strictEqual(result.code, 0);
 });
 
-test("should throw syntax error for invalid typescript", async () => {
+test("should throw syntax error for invalid typescript", async (t) => {
 	const result = await spawnPromisified(process.execPath, [
 		"--experimental-strip-types",
 		"--no-warnings",
 		"--import=./dist/register-strip.mjs",
 		fixturesPath("invalid-syntax.ts"),
 	]);
-
 	strictEqual(result.stdout, "");
 	match(result.stderr, /SyntaxError/);
 	match(result.stderr, /await isn't allowed in non-async function/);

--- a/test/snapshots/transform.test.js.snapshot
+++ b/test/snapshots/transform.test.js.snapshot
@@ -1,3 +1,29 @@
+exports[`should have proper error code 1`] = `
+{
+  "code": "UnsupportedSyntax",
+  "message": "\`module\` keyword is not supported. Use \`namespace\` instead.",
+  "snippet": "   \\n        \\n     module F { export type x = number }\\n     ^^^^^^^^\\n        \\n",
+  "filename": "<anon>",
+  "startLine": 1,
+  "startColumn": 0,
+  "endLine": 1,
+  "endColumn": 8
+}
+`;
+
+exports[`should have proper error code 2`] = `
+{
+  "code": "InvalidSyntax",
+  "message": "'const' declarations must be initialized",
+  "snippet": "   \\n        \\n     const foo;\\n           ^^^\\n        \\n",
+  "filename": "<anon>",
+  "startLine": 1,
+  "startColumn": 6,
+  "endLine": 1,
+  "endColumn": 9
+}
+`;
+
 exports[`should not polyfill using Symbol.Dispose 1`] = `
 "using r = 0;\\n"
 `;

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -326,6 +326,7 @@ test("should have proper error code", (t) => {
 			mode: "transform",
 		});
 	} catch (error) {
+		t.assert.snapshot(error);
 		assert.strictEqual(error.code, "UnsupportedSyntax");
 	}
 });
@@ -337,6 +338,7 @@ test("should have proper error code", (t) => {
 			mode: "transform",
 		});
 	} catch (error) {
+		t.assert.snapshot(error);
 		assert.strictEqual(error.code, "InvalidSyntax");
 	}
 });


### PR DESCRIPTION
This change is more useful in Node.js core than in Amaro as an external loader. Unfortunately snippets are not working so that's blocking