### PR TITLE
test: add snapshot for advanced type-level constructs

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -275,3 +275,20 @@ if(!((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
 }`;
 	assert.doesNotThrow(() => transformSync(source));
 });
+
+test("should handle advanced type-level constructs", (t) => {
+	const inputCode = `
+		type Fn = (x: string) => number;
+
+		type ReturnType<T> = T extends (...args: any) => infer R ? R : never;
+
+		type X = ReturnType<Fn>;
+
+		type Props = { id: string; name: string };
+		type Keys = keyof Props;
+
+		type A = typeof Math;
+	`;
+	const { code } = transformSync(inputCode);
+	t.assert.snapshot(code);
+});

--- a/test/snapshots/index.test.js.snapshot
+++ b/test/snapshots/index.test.js.snapshot
@@ -18,6 +18,10 @@ exports[`should handle User type and isAdult function 1`] = `
 "\\n                 \\n                   \\n                  \\n      \\n\\n    function isAdult(user      )          {\\n      return user.age >= 18;\\n    }\\n  "
 `;
 
+exports[`should handle advanced type-level constructs 1`] = `
+"\\n\\t\\t                                \\n\\n\\t\\t                                                                     \\n\\n\\t\\t                        \\n\\n\\t\\t                                          \\n\\t\\t                        \\n\\n\\t\\t                     \\n\\t"
+`;
+
 exports[`should handle class modifiers 1`] = `
 "\\n\\t\\tclass PrivateConstructor {\\n\\t\\t          constructor() {}\\n\\t\\t         a() {}\\n\\t\\t            b() {}\\n\\t\\t  static create() {\\n\\t\\t    return new PrivateConstructor()\\n\\t\\t  }\\n\\t\\t}\\n\\n\\t\\tconst ins = PrivateConstructor.create()\\n\\t\\tconsole.log(ins)\\n\\t"
 `;


### PR DESCRIPTION
This test ensures that `transformSync` can safely strip advanced TypeScript type-level constructs like:

- infer
- keyof
- typeof

All constructs are removed correctly using `mode: "strip-only"` and generate no runtime output, as expected.

Snapshot was generated using `NODE_TEST_UPDATE_SNAPSHOTS=1`.

No runtime behavior is affected. Test passed successfully under Node.js v24.0.0.