### PR TITLE
test: add snapshot for satisfies expressions

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -292,3 +292,14 @@ test("should handle advanced type-level constructs", (t) => {
 	const { code } = transformSync(inputCode);
 	t.assert.snapshot(code);
 });
+
+test("should strip 'satisfies' expressions", (t) => {
+	const inputCode = `
+		const user = {
+			name: "Alice",
+			age: 30,
+		} satisfies { name: string, age: number };
+	`;
+	const { code } = transformSync(inputCode);
+	t.assert.snapshot(code);
+});

--- a/test/snapshots/index.test.js.snapshot
+++ b/test/snapshots/index.test.js.snapshot
@@ -50,6 +50,10 @@ exports[`should perform type stripping on nested generics 1`] = `
 "const promiseWrapper = new Wrapper                         (Promise.resolve.bind(Promise));"
 `;
 
+exports[`should strip 'satisfies' expressions 1`] = `
+"\\n\\t\\tconst user = {\\n\\t\\t\\tname: \\"Alice\\",\\n\\t\\t\\tage: 30,\\n\\t\\t}                                        ;\\n\\t"
+`;
+
 exports[`should strip type annotations from arrow functions 1`] = `
 "\\n    const greet = (name        )       => {\\n      console.log(name);\\n    };\\n  "
 `;


### PR DESCRIPTION
This test ensures that `transformSync` can safely strip satisfies expressions.

The expression:
```
const user = {
	name: "Alice",
	age: 30,
} satisfies { name: string, age: number };
```

All constructs are removed correctly using mode: "strip-only", as expected.

A Snapshot was generated.

No runtime behavior is affected. 

Node.js v24.1.0