### PR TITLE
test: add snapshot for import/export type declarations

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -303,3 +303,12 @@ test("should strip 'satisfies' expressions", (t) => {
 	const { code } = transformSync(inputCode);
 	t.assert.snapshot(code);
 });
+
+test("should preserve import/export type declarations", (t) => {
+	const inputCode = `
+		import type { SomeType } from "./types";
+		export type { SomeType };
+	`;
+	const { code } = transformSync(inputCode);
+	t.assert.snapshot(code);
+});

--- a/test/snapshots/index.test.js.snapshot
+++ b/test/snapshots/index.test.js.snapshot
@@ -50,6 +50,10 @@ exports[`should perform type stripping on nested generics 1`] = `
 "const promiseWrapper = new Wrapper                         (Promise.resolve.bind(Promise));"
 `;
 
+exports[`should preserve import/export type declarations 1`] = `
+"\\n\\t\\t                                        \\n\\t\\t                         \\n\\t"
+`;
+
 exports[`should strip 'satisfies' expressions 1`] = `
 "\\n\\t\\tconst user = {\\n\\t\\t\\tname: \\"Alice\\",\\n\\t\\t\\tage: 30,\\n\\t\\t}                                        ;\\n\\t"
 `;


### PR DESCRIPTION
This test ensures that `transformSync` preserves valid `import type` and `export type` declarations

```
import type { SomeType } from "./types";
export type { SomeType };
```

All constructs are removed correctly using mode: "strip-only", as expected. A Snapshot was generated.
Node.js v24.3.0
