### PR TITLE
test: add snapshot for short-circuit assignments

### DIFF
--- a/test/snapshots/transform.test.js.snapshot
+++ b/test/snapshots/transform.test.js.snapshot
@@ -1,3 +1,7 @@
+exports[`should handle short-circuit assignments (&&=, ||=, ??=) 1`] = `
+"const a = {};\\na.foo &&= \`\${a.foo}1\`;\\nconsole.log(a.foo);\\nconst b = {};\\nb.foo ||= \`\${b.foo}1\`;\\nconsole.log(b.foo);\\nconst c = {};\\nc.foo ??= \`\${c.foo}1\`;\\nconsole.log(c.foo);\\n"
+`;
+
 exports[`should have proper error code 1`] = `
 {
   "code": "UnsupportedSyntax",

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -342,3 +342,28 @@ test("should have proper error code", (t) => {
 		assert.strictEqual(error.code, "InvalidSyntax");
 	}
 });
+
+test("should handle short-circuit assignments (&&=, ||=, ??=)", (t) => {
+	const inputCode = `
+		const a = {}
+
+		a.foo &&= \`\${a.foo}1\`
+		console.log(a.foo)
+
+		const b = {}
+
+		b.foo ||= \`\${b.foo}1\`
+		console.log(b.foo)
+
+		const c = {}
+
+		c.foo ??= \`\${c.foo}1\`
+		console.log(c.foo)
+	`;
+
+	const { code } = transformSync(inputCode, {
+		mode: "transform",
+		sourceMap: true,
+	});
+	t.assert.snapshot(code);
+});


### PR DESCRIPTION
This PR adds a test to prevent regressions on an already fixed issue, reported here: https://github.com/nodejs/node/issues/59737