### PR TITLE
docs: clarify type stripping behavior in node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ node --experimental-transform-types --import="amaro/transform" file.ts
 
 #### Type stripping in dependencies
 
-When used as a loader, Amaro can handle TypeScript files inside folders under a `node_modules` path.
-However, recent Node.js versions disallow type stripping for files under `node_modules` and throw
-`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. As a result, type stripping in dependencies does not
-work on those Node.js versions when using Amaro as a loader.
+When used as a loader, Amaro still relies on Node.js module loading. For this reason when trying to execute files under `node_modules` it throws
+`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. As a result, type stripping in dependencies does not work.
 
 ### Monorepo usage
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,10 @@ node --experimental-transform-types --import="amaro/transform" file.ts
 
 #### Type stripping in dependencies
 
-When used as a loader, Amaro attempts to handle TypeScript files inside folders under a `node_modules` path.
+When used as a loader, Amaro can handle TypeScript files inside folders under a `node_modules` path.
 However, recent Node.js versions disallow type stripping for files under `node_modules` and throw
-`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. This behavior is enforced by Node.js and changed after
-`--experimental-strip-types` was unflagged. As a result, type stripping in dependencies does not work on
-current Node.js versions when using Amaro as a loader.
+`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. As a result, type stripping in dependencies does not
+work on those Node.js versions when using Amaro as a loader.
 
 ### Monorepo usage
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ node --experimental-transform-types --import="amaro/transform" file.ts
 When used as a loader, Amaro attempts to handle TypeScript files inside folders under a `node_modules` path.
 However, recent Node.js versions disallow type stripping for files under `node_modules` and throw
 `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. This behavior is enforced by Node.js and changed after
-`--experimental-strip-types` was unflagged. As a result, type stripping in dependencies may not work on
+`--experimental-strip-types` was unflagged. As a result, type stripping in dependencies does not work on
 current Node.js versions when using Amaro as a loader.
 
 ### Monorepo usage

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ node --experimental-transform-types --import="amaro/transform" file.ts
 
 #### Type stripping in dependencies
 
-Contrary to the Node.js [TypeScript support](https://nodejs.org/docs/latest/api/typescript.html#type-stripping-in-dependencies), when used as a loader, Amaro handles TypeScript files inside folders under a `node_modules` path.
+When used as a loader, Amaro attempts to handle TypeScript files inside folders under a `node_modules` path.
+However, recent Node.js versions disallow type stripping for files under `node_modules` and throw
+`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. This behavior is enforced by Node.js and changed after
+`--experimental-strip-types` was unflagged. As a result, type stripping in dependencies may not work on
+current Node.js versions when using Amaro as a loader.
 
 ### Monorepo usage
 


### PR DESCRIPTION
## Summary

This PR updates the README to clarify the current behavior of type stripping under `node_modules` when Amaro is used as a loader.

Recent Node.js versions block type stripping for files inside `node_modules`, which causes Node.js to throw `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. This restriction is enforced by Node.js itself.

---

## Motivation

The README currently implies that type stripping in dependencies works when using Amaro as a loader.  
However, after `--experimental-strip-types` was unflagged, Node.js disallows this behavior and throws an error instead.

This change aligns the documentation with current Node.js behavior and avoids confusion for users.

---

## Changes

- Update the **“Type stripping in dependencies”** section in `README.md`
- Clarify that:
  - The limitation is enforced by Node.js
  - The behavior changed after `--experimental-strip-types` was unflagged
  - This is not an Amaro bug

---

## References

- Fixes #362
- Node.js regression: `nodejs/node@53b1050`

---

## Checklist

- [x] Documentation-only change
- [x] No code changes
- [x] Tests not required
