### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   commit-lint:
     name: Commit Lint


### PR DESCRIPTION
Pins the workflow `GITHUB_TOKEN` to read-only for `ci.yml`. All three jobs are read-only against the GitHub API: `commit-lint` runs `wagoid/commitlint-github-action`, `code-quality` runs `biomejs/setup-biome` + `biome ci`, `build-and-test` runs the node matrix across ubuntu/macos/windows. No registry push, no PR comment, nothing that needs more than `contents: read`.

Defense-in-depth motivation is the [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) shape: a compromised third-party action (and there are three here) runs inside the existing job context and exfiltrates whatever scope the workflow token was issued at. The explicit cap bounds the blast radius.

Matches the `read-all` shorthand already used in `scorecard.yml`. YAML validated locally with `yaml.safe_load`.