### PR TITLE
ci: declare workflow-level contents: read on ci and build-swc

### DIFF
--- a/.github/workflows/build-swc.yml
+++ b/.github/workflows/build-swc.yml
@@ -6,6 +6,9 @@ on:
       - 'tools/*'
       - 'deps/*'
 
+permissions:
+  contents: read
+
 jobs:
   build-swc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   commit-lint:
     name: Commit Lint


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level. No GitHub API writes from the workflow.

Post-CVE-2025-30066 hardening pattern. YAML validated locally.